### PR TITLE
Change format result data to slice

### DIFF
--- a/.github/workflows/testingv3.yml
+++ b/.github/workflows/testingv3.yml
@@ -1,0 +1,69 @@
+# Name of the workflow needs to match the name of the major version directory
+name: v2
+on:
+  push:
+    paths:
+      - 'v3/**'
+  pull_request:
+    paths:
+      - 'v3/**'
+
+jobs:
+  build:
+    name: Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.11.x', '1.12.x', '1.13.x' ]
+    env:
+      TEST_KDC_ADDR: 127.0.0.1
+      TEST_HTTP_URL: http://cname.test.gokrb5
+      TEST_HTTP_ADDR: 127.0.0.1
+      DNS_IP: 127.0.88.53
+      DNSUTILS_OVERRIDE_NS: 127.0.88.53:53
+    steps:
+      - name: Set up Go ${{ matrix.go }}
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Test well formatted with gofmt
+        run: |
+          GO_FILES=$(find ${GITHUB_WORKFLOW} -iname '*.go' -type f | grep -v /vendor/)
+          test -z $(gofmt -s -d -l -e $GO_FILES | tee /dev/fd/2 | xargs | sed 's/\s//g')
+        id: gofmt
+
+      - name: Go vet
+        run: |
+          cd ${GITHUB_WORKFLOW}
+          go vet ./...
+        id: govet
+
+      - name: Start integration test dependencies
+        run: |
+          sudo docker run -d -h ns.test.gokrb5 -v /etc/localtime:/etc/localtime:ro -e "TEST_KDC_ADDR=${TEST_KDC_ADDR}" -e "TEST_HTTP_ADDR=${TEST_HTTP_ADDR}" -p ${DNSUTILS_OVERRIDE_NS}:53 -p ${DNSUTILS_OVERRIDE_NS}:53/udp --name dns jcmturner/gokrb5:dns
+          sudo sed -i 's/nameserver .*/nameserver '${DNS_IP}'/g' /etc/resolv.conf
+          dig _kerberos._udp.TEST.GOKRB5
+        id: intgTestDeps
+
+      - name: Unit tests
+        run: |
+          cd ${GITHUB_WORKFLOW}
+          go test -race ./...
+        env:
+          INTEGRATION: 1
+        id: unitTests
+
+      - name: Unit tests (32bit)
+        run: |
+          cd ${GITHUB_WORKFLOW}
+          go test ./...
+        env:
+          GOARCH: 386
+          INTEGRATION: 1
+        id: unitTest32

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -1,0 +1,5 @@
+module github.com/jcmturner/dnsutils/v3
+
+go 1.13
+
+require github.com/stretchr/testify v1.4.0

--- a/v3/go.sum
+++ b/v3/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/v3/srv.go
+++ b/v3/srv.go
@@ -26,6 +26,11 @@ func OrderedSRV(service, proto, name string) (int, []*net.SRV, error) {
 }
 
 func OrderSRV(addrs []*net.SRV) (int, []*net.SRV) {
+	// No need to process less than two records
+	if cnt := len(addrs); cnt < 2 {
+		return cnt, addrs
+	}
+
 	// Initialise the ordered map
 	osrv := make([]*net.SRV, 0, len(addrs))
 

--- a/v3/srv.go
+++ b/v3/srv.go
@@ -1,0 +1,89 @@
+package dnsutils
+
+import (
+	"math/rand"
+	"net"
+	"sort"
+)
+
+// OrderedSRV returns a count of the results and a map keyed on the order they should be used.
+// This based on the records' priority and randomised selection based on their relative weighting.
+// The function's inputs are the same as those for net.LookupSRV
+// To use in the correct order:
+//
+// count, orderedSRV, err := OrderedSRV(service, proto, name)
+//
+//	for  _, srv := range orderedSRV {
+//	  // Do something such as dial this SRV. If fails move on the the next or break if it succeeds.
+//	}
+func OrderedSRV(service, proto, name string) (int, []*net.SRV, error) {
+	_, addrs, err := net.LookupSRV(service, proto, name)
+	if err != nil {
+		return 0, nil, err
+	}
+	index, osrv := OrderSRV(addrs)
+	return index, osrv, nil
+}
+
+func OrderSRV(addrs []*net.SRV) (int, []*net.SRV) {
+	// Initialise the ordered map
+	osrv := make([]*net.SRV, 0, len(addrs))
+
+	prioMap := make(map[int][]*net.SRV, 0)
+	for _, srv := range addrs {
+		prioMap[int(srv.Priority)] = append(prioMap[int(srv.Priority)], srv)
+	}
+
+	priorities := make([]int, 0, len(prioMap))
+	for p := range prioMap {
+		priorities = append(priorities, p)
+	}
+
+	var count int
+	sort.Ints(priorities)
+	for _, p := range priorities {
+		tos := weightedOrder(prioMap[p])
+		for _, s := range tos {
+			count++
+			osrv = append(osrv, s)
+		}
+	}
+	return count, osrv
+}
+
+func weightedOrder(srvs []*net.SRV) []*net.SRV {
+	// Get the total weight
+	var tw int
+	for _, s := range srvs {
+		tw += int(s.Weight)
+	}
+
+	// Initialise the ordered map
+	osrv := make([]*net.SRV, 0, len(srvs))
+
+	// Whilst there are still entries to be ordered
+	l := len(srvs)
+	for l > 0 {
+		i := rand.Intn(l)
+		s := srvs[i]
+		var rw int
+		if tw > 0 {
+			// Greater the weight the more likely this will be zero or less
+			rw = rand.Intn(tw) - int(s.Weight)
+		}
+		if rw <= 0 {
+			// Put entry in position
+			osrv = append(osrv, s)
+			if len(srvs) > 1 {
+				// Remove the entry from the source slice by swapping with the last entry and truncating
+				srvs[len(srvs)-1], srvs[i] = srvs[i], srvs[len(srvs)-1]
+				srvs = srvs[:len(srvs)-1]
+				l = len(srvs)
+			} else {
+				l = 0
+			}
+			tw = tw - int(s.Weight)
+		}
+	}
+	return osrv
+}

--- a/v3/srv.go
+++ b/v3/srv.go
@@ -57,6 +57,11 @@ func OrderSRV(addrs []*net.SRV) (int, []*net.SRV) {
 }
 
 func weightedOrder(srvs []*net.SRV) []*net.SRV {
+	// No need to process less than two records
+	if len(srvs) < 2 {
+		return srvs
+	}
+
 	// Get the total weight
 	var tw int
 	for _, s := range srvs {

--- a/v3/srv_integration_test.go
+++ b/v3/srv_integration_test.go
@@ -1,0 +1,41 @@
+package dnsutils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestResolveKDC(t *testing.T) {
+	if os.Getenv("INTEGRATION") != "1" {
+		t.Skip("Skipping integration test.")
+	}
+	for i := 0; i < 100; i++ {
+		count, res, err := OrderedSRV("kerberos", "tcp", "test.gokrb5")
+		if err != nil {
+			t.Errorf("error resolving SRV DNS records: %v", err)
+		}
+		expected := []string{
+			"kdc.test.gokrb5:88",
+			"kdc1a.test.gokrb5:88",
+			"kdc2a.test.gokrb5:88",
+			"kdc1b.test.gokrb5:88",
+			"kdc2b.test.gokrb5:88",
+		}
+		assert.Equal(t, len(expected), count, "Number of SRV records not as expected: %v", res)
+		assert.Equal(t, count, len(res), "Map size does not match: %v", res)
+		for _, s := range expected {
+			var found bool
+			for _, v := range res {
+				srvStr := strings.TrimRight(v.Target, ".") + ":" + strconv.Itoa(int(v.Port))
+				if s == srvStr {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "Record %s not found in results", s)
+		}
+	}
+}

--- a/v3/srv_test.go
+++ b/v3/srv_test.go
@@ -1,0 +1,42 @@
+package dnsutils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net"
+	"testing"
+)
+
+func TestOrderSRV(t *testing.T) {
+	srv11 := net.SRV{
+		Target:   "t11",
+		Port:     1234,
+		Priority: 1,
+		Weight:   100,
+	}
+	srv12 := net.SRV{
+		Target:   "t12",
+		Port:     1234,
+		Priority: 1,
+		Weight:   100,
+	}
+	srv13 := net.SRV{
+		Target:   "t13",
+		Port:     1234,
+		Priority: 1,
+		Weight:   20,
+	}
+	srv21 := net.SRV{
+		Target:   "t21",
+		Port:     1234,
+		Priority: 2,
+		Weight:   1,
+	}
+
+	addrs := []*net.SRV{
+		&srv11, &srv21, &srv12, &srv13,
+	}
+	count, orderedSRV := OrderSRV(addrs)
+	assert.Equal(t, len(addrs), count, "Index not the expected size")
+	assert.Equal(t, len(addrs), len(orderedSRV), "orderedSRV not the expected size")
+	assert.Equal(t, uint16(2), orderedSRV[3].Priority, "Priority order not as expected")
+}


### PR DESCRIPTION
The format of the returned data has been changed from a map to a slice, since in a slice the data is already arranged in the required order.
Made as v3 since there is no backward compatibility.
The OrderSRV function was made public in order to make it possible in user functions to optionally sort data already received through net.LookupSRV and there was no need to go through this procedure again (DNS queries can be very long).
For example:
```go
func ServiceDiscovery(service, proto, host string, sortWithWeight bool) ([]string, error) {
	_, addrs, err := net.LookupSRV(service, proto, host)
	if err != nil {
		return nil, err
	}
	if sortWithWeight {
		_, addrs = OrderSRV(addrs)
	}

	result := make([]string, len(addrs))
	for i, srv := range addrs {
		result[i] = strings.TrimRight(srv.Target, ".") + ":" + strconv.Itoa(int(srv.Port))
	}

	return result, nil
}
```